### PR TITLE
feat: Add backKeyIcon field

### DIFF
--- a/lib/src/custom_keyboard.dart
+++ b/lib/src/custom_keyboard.dart
@@ -10,6 +10,9 @@ class CustomKeyBoard extends StatefulWidget {
   /// special key to be displayed on the widget. Default is '.'
   final Widget? specialKey;
 
+  /// back key icon to be displayed on the widget. Default is `Icons.backspace`
+  final IconData? backKeyIcon;
+
   /// on changed function to be called when the amount is changed.
   final Function(String)? onChanged;
 
@@ -31,6 +34,7 @@ class CustomKeyBoard extends StatefulWidget {
       required this.maxLength,
       this.pinTheme = const PinTheme.defaults(),
       this.specialKey,
+      this.backKeyIcon,
       this.onChanged,
       this.specialKeyOnTap,
       this.onCompleted,
@@ -134,7 +138,7 @@ class _CustomKeyBoardState extends State<CustomKeyBoard> {
           ),
           buildNumberButton(
               icon: Icon(
-                Icons.backspace,
+                widget.backKeyIcon ?? Icons.backspace,
                 key: const Key('backspace'),
                 color: widget.pinTheme.keysColor,
               ),


### PR DESCRIPTION
<img width="612" alt="image" src="https://github.com/user-attachments/assets/150102f9-8399-4403-ae22-568f0a38bcae">

```dart
          CustomKeyBoard(
            controller: controller,
            pinTheme: PinTheme(
              textColor: Colors.red,
              keysColor: Colors.blue,
            ),
            backKeyIcon: Icons.arrow_back,
            maxLength: 4,
          ),
```

<img width="612" alt="image" src="https://github.com/user-attachments/assets/aa091dc5-4c9e-4d93-b9ee-bba5ad8dedea">

```dart
          CustomKeyBoard(
            controller: controller,
            pinTheme: PinTheme(
              textColor: Colors.red,
              keysColor: Colors.blue,
            ),
            backKeyIcon: Icons.mail,
            maxLength: 4,
          ),
```
